### PR TITLE
Fix assert in '- setSelectedSegmentIndex:' when a negative parameter is given (e.g., UISegmentedControlNoSegment)

### DIFF
--- a/SDSegmentedControl.m
+++ b/SDSegmentedControl.m
@@ -222,7 +222,7 @@
 {
     if (_selectedSegmentIndex != selectedSegmentIndex)
     {
-        NSParameterAssert(selectedSegmentIndex < self._items.count);
+        NSParameterAssert(selectedSegmentIndex < (NSInteger)self._items.count);
         _selectedSegmentIndex = selectedSegmentIndex;
         [self setNeedsLayout];
     }


### PR DESCRIPTION
This is a pretty common issue when comparing signed and unsigned integers, casting is necessary.
