### PR TITLE
Changed _items initialization to avoid EXC_BAD_ACCESS crash

### DIFF
--- a/SDSegmentedControl.m
+++ b/SDSegmentedControl.m
@@ -85,7 +85,7 @@ const CGFloat kSDSegmentedControlScrollOffset = 20;
     _selectedSegmentIndex = -1;
     _interItemSpace = kSDSegmentedControlInterItemSpace;
     _stainEdgeInsets = kSDSegmentedControlStainEdgeInsets;
-    __items = NSMutableArray.array;
+    self._items = NSMutableArray.array;
 
     // Appearance properties
     _animationDuration = kSDSegmentedControlDefaultDuration;


### PR DESCRIPTION
Somehow _items property is not propely initialized when directly accessed in commonInit. It then causes EXC_BAD_ACCESS crash when looping self._items in layoutSegments.

(I don't use Interface Builder and initialize control via [[SDSegmentedControl alloc] initWithItems:...])
