### PR TITLE
Avoid upscaling images smaller than -imageSize

### DIFF
--- a/SDSegmentedControl.m
+++ b/SDSegmentedControl.m
@@ -954,7 +954,8 @@ const CGFloat kSDSegmentedControlScrollOffset = 20;
 {
     if (!image) return nil;
 
-    if (!CGSizeEqualToSize(image.size, self.imageSize))
+    // Scale down images that are too large 
+    if (image.size.width > self.imageSize.width || image.size.height > self.imageSize.height)
     {
         UIImageView *imageView = [UIImageView.alloc initWithFrame:CGRectMake(0, 0, self.imageSize.width, self.imageSize.height)];
         imageView.contentMode = UIViewContentModeScaleAspectFit;


### PR DESCRIPTION
Avoids upscaling images that are smaller than `-imageSize`. Improves appearance of icons smaller than the default image size without requiring the image size to be changed.

This is especially helpful if the icons on some controls have different sizes. It effectively transforms the `imageSize` property into a maximum rather than an exact fit. This is just a convenience, the developer could set the proper `imageSize` but the maximum size concept is easier.
