### PR TITLE
Resize SDSegmentView after TitleFont has been changed

### DIFF
--- a/SDSegmentedControl.m
+++ b/SDSegmentedControl.m
@@ -1121,16 +1121,6 @@ const CGFloat kSDSegmentedControlScrollOffset = 20;
     return innerFrame;
 }
 
-- (void)setItemFont:(UIFont *)itemFont
-{
-    self.titleLabel.font = itemFont;
-}
-
-- (UIFont *)itemFont
-{
-    return self.titleLabel.font;
-}
-
 @end
 
 
@@ -1140,7 +1130,6 @@ const CGFloat kSDSegmentedControlScrollOffset = 20;
 {
     [super initialize];
     SDStainView *appearance = [self appearance];
-    appearance.backgroundColor = [UIColor colorWithWhite:0.816 alpha:1];
     appearance.edgeInsets = UIEdgeInsetsMake(-.5, -.5, -.5, -.5);
 
     if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1)


### PR DESCRIPTION
SDSegmentView's size was set according to the font which was assigned in initWithFrame. This fix resizes the view after setting up the font.
Cleaned up some code that have been added for ios7 support
