### PR TITLE
Quiet warning by giving property explicit assign/nonatomic settings

### DIFF
--- a/SDSegmentedControl.h
+++ b/SDSegmentedControl.h
@@ -29,7 +29,7 @@
 @property (assign, nonatomic) CGFloat shadowOpacity UI_APPEARANCE_SELECTOR;
 @property (assign, nonatomic) CGSize shadowOffset UI_APPEARANCE_SELECTOR;
 
-@property UIScrollView *scrollView;
+@property (assign,nonatomic) UIScrollView *scrollView;
 
 @end
 


### PR DESCRIPTION
With LLVM 5 (and apparently 4.2 -- see issue #39) you get compiler warnings if you don't specify the property type.
